### PR TITLE
Updated to work with std futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,13 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-futures = "0.1.28"
-rustls = "0.15.2"
-tokio-io = "0.1.12"
-tokio-postgres = "0.4.0-rc.3"
-tokio-rustls = "0.10.0-alpha.3"
-webpki = "0.19.1"
+rustls = "0.16.0"
+tokio-io = "=0.2.0-alpha.6"
+tokio-postgres = "0.5.0-alpha.1"
+tokio-rustls = { git = "https://github.com/quininer/tokio-rustls", branch = "tokio-0.2"}
+webpki = "0.21.0"
 
 [dev-dependencies]
-tokio = "0.1.21"
+tokio = "0.2.0-alpha.6"
+tokio-test = "0.2.0-alpha.6"
+futures-util-preview = "0.3.0-alpha.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,27 @@
-use std::{
-    io,
-    sync::Arc,
-};
+use std::{future::Future, io, pin::Pin, sync::Arc};
 
-use futures::Future;
 use rustls::ClientConfig;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_postgres::tls::{ChannelBinding, MakeTlsConnect, TlsConnect};
 use tokio_rustls::{client::TlsStream, TlsConnector};
 use webpki::{DNSName, DNSNameRef};
 
-
+#[derive(Clone)]
 pub struct MakeRustlsConnect {
     config: Arc<ClientConfig>,
 }
 
 impl MakeRustlsConnect {
     pub fn new(config: ClientConfig) -> Self {
-        Self { config: Arc::new(config) }
+        Self {
+            config: Arc::new(config),
+        }
     }
 }
 
 impl<S> MakeTlsConnect<S> for MakeRustlsConnect
 where
-    S: AsyncRead + AsyncWrite + Send + 'static
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Stream = TlsStream<S>;
     type TlsConnect = RustlsConnect;
@@ -46,44 +44,56 @@ pub struct RustlsConnect {
 
 impl<S> TlsConnect<S> for RustlsConnect
 where
-    S: AsyncRead + AsyncWrite + Send + 'static
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Stream = TlsStream<S>;
     type Error = io::Error;
-    type Future = Box<dyn Future<Item=(Self::Stream, ChannelBinding), Error=Self::Error> + Send>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<(Self::Stream, ChannelBinding), Self::Error>> + Send>>;
 
     fn connect(self, stream: S) -> Self::Future {
-        Box::new(
-            self.connector.connect(self.hostname.as_ref(), stream)
-                .map(|s| (s, ChannelBinding::none()))  // TODO
-        )
+        let future = async move {
+            let stream: TlsStream<S> = self
+                .connector
+                .connect(self.hostname.as_ref(), stream)
+                .await?;
+
+            Ok((stream, ChannelBinding::none()))
+        };
+
+        Box::pin(future)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use futures::{Future, Stream};
-    use tokio::runtime::current_thread;
+    use futures_util::future::FutureExt;
+    use tokio_postgres::Row;
 
-    #[test]
-    fn it_works() {
+    #[tokio::test]
+    async fn it_works() -> Result<(), tokio_postgres::Error> {
         let config = rustls::ClientConfig::new();
         let tls = super::MakeRustlsConnect::new(config);
-        current_thread::block_on_all(
-            tokio_postgres::connect("sslmode=require host=localhost user=postgres", tls)
-                .map(|(client, connection)| {
-                    tokio::spawn(
-                        connection.map_err(|e| panic!("{:?}", e))
-                    );
-                    client
-                })
-                .and_then(|mut client| {
-                    client.prepare("SELECT 1")
-                        .map(|s| (client, s))
-                })
-                .and_then(|(mut client, statement)| {
-                    client.query(&statement, &[]).collect()
-                })
-        ).unwrap();
+
+        let (client, connection) = tokio_postgres::connect(
+            "sslmode=require host=localhost user=postgres",
+            tls,
+        )
+        .await?;
+
+        // spawn connection on tokio
+        let connection = connection.map(|r| {
+            if let Err(e) = r {
+                panic!("connection error: {}", e);
+            }
+        });
+        tokio::spawn(connection);
+
+        let stmt = client.prepare("SELECT $1::TEXT").await?;
+        let rows: Vec<Row> = client.query(&stmt, &[&"hello world"]).await?;
+        let value: &str = rows[0].get(0);
+        assert_eq!(value, "hello world");
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Hey @jbg I wanted to play around with the latest release of tokio-postgres with rustls so I've updated your library to the latest version of libraries from the ecosystem. I've tried not to changed the API surface. I only changed things related to std futures around pinning, and I've added the Clone bound to the _MakeRustlsConnect_ because I needed that for connection pool I'm using. 

This of course doesn't work on stable rust, only beta / nightly for a few more days.

I understand if you never want to merge this into master as is, and wait for the ecosystem to do proper releases. If you want I can update this PR when the other libraries stabilize in some near future.