### PR TITLE
updated dependencies rustls and tokio-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ tokio-rustls = "0.23"
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }
 tokio = { version = "1", features = ["macros", "rt"] }
+rustls = { version = "0.20", features = ["dangerous_configuration"] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-postgres-rustls"
 description = "Rustls integration for tokio-postgres"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Jasper Hugo <jasper@jasperhugo.com>"]
 repository = "https://github.com/jbg/tokio-postgres-rustls"
 edition = "2018"
@@ -11,11 +11,10 @@ readme = "README.md"
 [dependencies]
 futures = "0.3"
 ring = "0.16"
-rustls = "0.19"
+rustls = "0.20"
 tokio = "1"
 tokio-postgres = "0.7"
-tokio-rustls = "0.22"
-webpki = "0.21"
+tokio-rustls = "0.23"
 
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-postgres-rustls"
 description = "Rustls integration for tokio-postgres"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Jasper Hugo <jasper@jasperhugo.com>"]
 repository = "https://github.com/jbg/tokio-postgres-rustls"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ and the [tokio-postgres asynchronous PostgreSQL client library](https://github.c
 # Example
 
 ```
-let config = rustls::ClientConfig::new();
+let config = rustls::ClientConfig::builder()
+    .with_safe_defaults()
+    .with_root_certificates(rustls::RootCertStore::empty())
+    .with_no_client_auth();
 let tls = tokio_postgres_rustls::MakeRustlsConnect::new(config);
 let connect_fut = tokio_postgres::connect("sslmode=require host=localhost user=postgres", tls);
 // ...


### PR DESCRIPTION
I had to disable any certificate verification for the unit test, because my setup uses a self-signed server cert. There seemed to be no simple way to support that without some configuration.