### PR TITLE
fix: Use correct digest for SCRAM channel binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rustls = { version = "0.21", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false }
 tokio-rustls = { version = "0.24", default-features = false }
+x509-certificate = {version = "0.21.0", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+use DigestAlgorithm::{Sha1, Sha256, Sha384, Sha512};
 
 use futures::future::{FutureExt, TryFutureExt};
 use ring::digest;
@@ -13,6 +14,10 @@ use rustls::{ClientConfig, ServerName};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_postgres::tls::{ChannelBinding, MakeTlsConnect, TlsConnect};
 use tokio_rustls::{client::TlsStream, TlsConnector};
+use x509_certificate::{algorithm, DigestAlgorithm, SignatureAlgorithm, X509Certificate};
+use SignatureAlgorithm::{
+    EcdsaSha256, EcdsaSha384, Ed25519, NoSignature, RsaSha1, RsaSha256, RsaSha384, RsaSha512,
+};
 
 #[derive(Clone)]
 pub struct MakeRustlsConnect {
@@ -83,10 +88,26 @@ where
     fn channel_binding(&self) -> ChannelBinding {
         let (_, session) = self.0.get_ref();
         match session.peer_certificates() {
-            Some(certs) if !certs.is_empty() => {
-                let sha256 = digest::digest(&digest::SHA256, certs[0].as_ref());
-                ChannelBinding::tls_server_end_point(sha256.as_ref().into())
-            }
+            Some(certs) if !certs.is_empty() => X509Certificate::from_der(&certs[0])
+                .ok()
+                .and_then(|cert| cert.signature_algorithm())
+                .map(|algorithm| match algorithm {
+                    // Note: SHA1 is upgraded to SHA256 as per https://datatracker.ietf.org/doc/html/rfc5929#section-4.1
+                    RsaSha1 | RsaSha256 | EcdsaSha256 => &digest::SHA256,
+                    RsaSha384 | EcdsaSha384 => &digest::SHA384,
+                    RsaSha512 => &digest::SHA512,
+                    Ed25519 => &digest::SHA512,
+                    NoSignature(algo) => match algo {
+                        Sha1 | Sha256 => &digest::SHA256,
+                        Sha384 => &digest::SHA384,
+                        Sha512 => &digest::SHA512,
+                    },
+                })
+                .map(|algorithm| {
+                    let hash = digest::digest(algorithm, certs[0].as_ref());
+                    ChannelBinding::tls_server_end_point(hash.as_ref().into())
+                })
+                .unwrap_or(ChannelBinding::none()),
             _ => ChannelBinding::none(),
         }
     }


### PR DESCRIPTION
Currently, when connecting to a server using a certificate with a
SHA2-384-based signature algorithm in "sslmode=require", the connection
fails with the following error:
"FATAL: SCRAM channel binding check failed".

This is because the client is hard-coded to use the SHA2-256 digest
algorithm to calculate the channel binding. The digest algorithm used
should be derived from the server's certificate.

This change parses the server's certificate, extracting the digest
algorithm and using that to calculate the channel binding.
