### PR TITLE
Upgrade ring to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-ring = { version = "0.16", default-features = false }
+ring = { version = "0.17", default-features = false }
 rustls = { version = "0.21", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false }


### PR DESCRIPTION
The only direct usage of `ring` is calling `ring::digest::digest` which has not changed from the 0.16.x ring releases.