### PR TITLE
Update x509-certificate from 0.21 to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ rustls = { version = "0.22.1", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false }
 tokio-rustls = { version = "0.25", default-features = false }
-x509-certificate = {version = "0.21.0", default-features = false }
+x509-certificate = {version = "0.23.0", default-features = false }
 
 [dev-dependencies]
-env_logger = { version = "0.8", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 tokio = { version = "1", features = ["macros", "rt"] }
 tokio-postgres = "0.7"
 rustls = { version = "0.22" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use rustls::pki_types::ServerName;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_postgres::tls::{ChannelBinding, MakeTlsConnect, TlsConnect};
 use tokio_rustls::{client::TlsStream, TlsConnector};
-use x509_certificate::{algorithm, DigestAlgorithm, SignatureAlgorithm, X509Certificate};
+use x509_certificate::{DigestAlgorithm, SignatureAlgorithm, X509Certificate};
 use SignatureAlgorithm::{
     EcdsaSha256, EcdsaSha384, Ed25519, NoSignature, RsaSha1, RsaSha256, RsaSha384, RsaSha512,
 };


### PR DESCRIPTION
This was causing us to pull in multiple versions of ring/pem, should probably make a 0.11.1 release