### PR TITLE
Use async blocks to remove dependency on FutureExt and TryFutureExt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-futures = { version = "0.3", default-features = false }
 ring = { version = "0.17", default-features = false }
 rustls = { version = "0.22.1", default-features = false }
 tokio = { version = "1", default-features = false }


### PR DESCRIPTION
the futures dependency is not required since async blocks exist in the language