### PR TITLE
Bump to rustls v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,17 @@ readme = "README.md"
 
 [dependencies]
 ring = { version = "0.17", default-features = false }
-rustls = { version = "0.22.1", default-features = false }
+rustls = { version = "0.23.1", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false }
 tokio-rustls = { version = "0.25", default-features = false }
 x509-certificate = {version = "0.23", default-features = false }
 
 [dev-dependencies]
-env_logger = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 tokio = { version = "1", features = ["macros", "rt"] }
 tokio-postgres = "0.7"
-rustls = { version = "0.22" }
+rustls = { version = "0.23" }
+
+[patch.crates-io]
+tokio-rustls = { git = "https://github.com/rustls/tokio-rustls", rev = "b3a2b143239d66253ba09f8ac4bfc4b7ab00cfac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ ring = { version = "0.17", default-features = false }
 rustls = { version = "0.23.1", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false }
-tokio-rustls = { version = "0.25", default-features = false }
+tokio-rustls = { version = "0.26", default-features = false }
 x509-certificate = {version = "0.23", default-features = false }
 
 [dev-dependencies]
@@ -21,6 +21,3 @@ env_logger = { version = "0.11", default-features = false }
 tokio = { version = "1", features = ["macros", "rt"] }
 tokio-postgres = "0.7"
 rustls = { version = "0.23" }
-
-[patch.crates-io]
-tokio-rustls = { git = "https://github.com/rustls/tokio-rustls", rev = "b3a2b143239d66253ba09f8ac4bfc4b7ab00cfac" }


### PR DESCRIPTION
WIP since it's blocked by the `tokio-rustls` upgrade

- https://github.com/rustls/tokio-rustls/pull/44

Also bumped the `env_logger` dependency since that was also out-of-date. But that's minor since it's only a test dependency.

---

Passes tests locally with my PostgreSQL instance. 