### PR TITLE
expose a feature flag to use aws_lc_rs instead of ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,30 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-ring = { version = "0.17", default-features = false }
+ring = { version = "0.17", default-features = false, optional = true }
+aws-lc-rs = { version = "1.8.0", optional = true }
 rustls = { version = "0.23", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false }
-x509-certificate = {version = "0.23", default-features = false }
+x509-certificate = { version = "0.23", default-features = false }
+
+[features]
+default = ["ring"]
+#aws_lc_rs = ["rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs", "dep:aws-lc-rs"]
+aws-lc-rs = ["dep:aws_lc_rs"]
+#ring = ["rustls/ring", "tokio-rustls/ring", "dep:ring"]
+ring = ["dep:ring"]
 
 [dev-dependencies]
 env_logger = { version = "0.11", default-features = false }
 tokio = { version = "1", default-features = false, features = ["macros", "rt"] }
-tokio-postgres = { version = "0.7", default-features = false, features = ["runtime"] }
-rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12", "ring"] }
+tokio-postgres = { version = "0.7", default-features = false, features = [
+    "runtime",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+    "std",
+    "logging",
+    "tls12",
+    "ring",
+] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,11 @@ use std::{
 };
 use DigestAlgorithm::{Sha1, Sha256, Sha384, Sha512};
 
+#[cfg(feature = "aws-lc-rs")]
+use aws_lc_rs::digest;
+#[cfg(feature = "ring")]
 use ring::digest;
+
 use rustls::pki_types::ServerName;
 use rustls::ClientConfig;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -144,7 +148,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test))]
 mod tests {
     use super::*;
     use rustls::pki_types::{CertificateDer, UnixTime};


### PR DESCRIPTION
even if the user overrides the rustls use aws_lc_rs this crate still uses ring for digest calculation. same behaviour with the same api exists in aws_lc_rs so this pr exposes a feature flag to switch between the two. To not break anything it still uses ring by default. One thing to add is to inform user by a compile error if both feature are enabled at the same time. I am thinking of doing it something like this lemme know if this looks ok

```rs
#[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
use aws_lc_rs::digest;
#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
use ring::digest;
#[cfg(all(feature = "ring", feature = "aws-lc-rs"))]
compile_error!("Please only enable 'aws-lc-rs' or 'ring'")
```