### PR TITLE
remove unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![forbid(rust_2018_idioms)]
-#![deny(missing_docs, unsafe_code)]
+#![forbid(missing_docs, unsafe_code)]
 #![warn(clippy::all, clippy::pedantic)]
 
 use std::{convert::TryFrom, sync::Arc};


### PR DESCRIPTION
Because of the requirement that `S: Unpin`, there's no need for awkward pin projection code. 

Alternatively, tokio already depends on [pin-project-lite](https://docs.rs/pin-project-lite/latest/pin_project_lite/) [unconditionally](https://github.com/tokio-rs/tokio/blob/0dbdd196b6a9af9a106c654a8613088b81a64655/tokio/Cargo.toml#L91). So if you don't want to rely on `Unpin`, we could switch to that instead.