### PR TITLE
Bump Rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Rustls integration for tokio-postgres"
 version = "0.13.0"
 authors = ["Jasper Hugo <jasper@jasperhugo.com>"]
 repository = "https://github.com/jbg/tokio-postgres-rustls"
-edition = "2018"
+edition = "2024"
 license = "MIT"
 readme = "README.md"
 
@@ -13,7 +13,9 @@ const-oid = { version = "0.9.6", default-features = false, features = ["db"] }
 ring = { version = "0.17", default-features = false }
 rustls = { version = "0.23", default-features = false }
 tokio = { version = "1", default-features = false }
-tokio-postgres = { version = "0.7", default-features = false }
+tokio-postgres = { version = "0.7", default-features = false, features = [
+  "runtime",
+] }
 tokio-rustls = { version = "0.26", default-features = false }
 x509-cert = { version = "0.2.5", default-features = false, features = ["std"] }
 


### PR DESCRIPTION
## Summary

Updates the crate to Rust edition 2024.

Enables the main tokio-postgres dependency's runtime feature so the public MakeTlsConnect API remains available in normal builds.